### PR TITLE
Put back correctness checks in every bench file.

### DIFF
--- a/fast/wave3d_b.py
+++ b/fast/wave3d_b.py
@@ -138,4 +138,3 @@ if args.xdsl:
 
 if args.xdsl and args.devito:
     print("Max error: ", np.max(np.abs(u.data - devito_out.data)))
-    

--- a/fast/wave3d_b.py
+++ b/fast/wave3d_b.py
@@ -63,10 +63,11 @@ t0 = 0.  # Simulation starts a t=0
 tn = nt  # Simulation last 1 second (1000 ms)
 
 # Define the wavefield with the size of the model and the time dimension
+# Define the wavefield with the size of the model and the time dimension
 u = TimeFunction(name="u", grid=grid, time_order=to, space_order=so)
 # Another one to clone data
 u2 = TimeFunction(name="u", grid=grid, time_order=to, space_order=so)
-ub = TimeFunction(name="ub", grid=grid, time_order=to, space_order=so)
+devito_out = TimeFunction(name="u", grid=grid, time_order=to, space_order=so)
 
 # We can now write the PDE
 # pde = model.m * u.dt2 - u.laplace + model.damp * u.dt
@@ -80,12 +81,12 @@ stencil = Eq(u.forward, solve(pde, u.forward))
 # print("Init Devito linalg norm 2 :", np.linalg.norm(u.data[2]))
 # print("Norm of initial data:", norm(u))
 
-configuration['mpi'] = 0
-u2.data[:] = u.data[:]
-configuration['mpi'] = mpiconf
-
 u.data[:] = np.load("so%s_wave_dat%s.npz" % (so, shape_str), allow_pickle=True)['arr_0']
 dt = np.load("so%s_critical_dt%s.npy" % (so, shape_str), allow_pickle=True)
+if args.xdsl and args.devito:
+    configuration['mpi'] = 0
+    u2.data[:] = u.data[:]
+    configuration['mpi'] = mpiconf
 
 # np.save("critical_dt%s.npy" % shape_str, model.critical_dt, allow_pickle=True)
 # np.save("wave_dat%s.npy" % shape_str, u.data[:], allow_pickle=True)
@@ -105,14 +106,16 @@ if args.devito:
     op1 = Operator([stencil], name='DevitoOperator')
     op1.apply(time=nt, dt=dt)
 
-    configuration['mpi'] = 0
-    ub.data[:] = u.data[:]
-    configuration['mpi'] = mpiconf
-
     if len(shape) == 3 and args.plot:
         plot_3dfunc(u)
 
     print("Devito norm:", norm(u))
+
+    if args.xdsl:
+        configuration['mpi'] = 0
+        devito_out.data[:] = u.data[:]
+        u.data[:] = u2.data[:]
+        configuration['mpi'] = mpiconf
     # print("Devito linalg norm 0:", np.linalg.norm(u.data[0]))
     # print("Devito linalg norm 1:", np.linalg.norm(u.data[1]))
     # print("Devito linalg norm 2:", np.linalg.norm(u.data[2]))
@@ -132,3 +135,7 @@ if args.xdsl:
     # print("XDSL output norm 0:", np.linalg.norm(u.data[0]))
     # print("XDSL output norm 1:", np.linalg.norm(u.data[1]))
     # print("XDSL output norm 2:", np.linalg.norm(u.data[2]))
+
+if args.xdsl and args.devito:
+    print("Max error: ", np.max(np.abs(u.data - devito_out.data)))
+    


### PR DESCRIPTION
This add a few boilerplate lines to every bench file to manage initial and output data from Devito and xDSL kernels,
so we can do a (rank-local if in MPI mode) proper comparison of their output.

Basically, if both kernels are run, save the input data before Devito executes, then retinitialize it for xDSL, while storing Devito's output for comparison after xDSL's run.

Here a simple max absolute error is computed.