### PR TITLE
CI: Use explicit docker tags.

### DIFF
--- a/.github/workflows/ci-mlir-mpi.yml
+++ b/.github/workflows/ci-mlir-mpi.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: papychacal/xdsl-llvm
+    container: papychacal/xdsl-llvm:04fc02e583b06b846315904a55af9c273c8b20b9
     steps:
     - name: Checkout Devito
       uses: actions/checkout@v3

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: papychacal/xdsl-llvm
+    container: papychacal/xdsl-llvm:04fc02e583b06b846315904a55af9c273c8b20b9
     steps:
     - name: Checkout Devito
       uses: actions/checkout@v3


### PR DESCRIPTION
To prepare to push different docker images without conflicting with the current usage of the latest.