### PR TITLE
Scripts: avoid Matplotlib if possible

### DIFF
--- a/fast/diffusion_2D_wBCs.py
+++ b/fast/diffusion_2D_wBCs.py
@@ -8,7 +8,6 @@ import numpy as np
 from devito import (Grid, TimeFunction, Eq, solve, Operator,
                     Constant, norm, configuration)
 from examples.cfd import init_hat
-from fast.bench_utils import plot_2dfunc
 
 parser = argparse.ArgumentParser(description='Process arguments.')
 
@@ -26,6 +25,9 @@ parser.add_argument("-plot", "--plot", default=False, type=bool, help="Plot2D")
 parser.add_argument("-devito", "--devito", default=False, type=bool, help="Devito run")
 parser.add_argument("-xdsl", "--xdsl", default=False, type=bool, help="xDSL run")
 args = parser.parse_args()
+
+if args.plot:
+    from fast.bench_utils import plot_2dfunc
 
 mpiconf = configuration['mpi']
 

--- a/fast/diffusion_3D_wBCs.py
+++ b/fast/diffusion_3D_wBCs.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from devito import (Grid, TimeFunction, Eq, solve, Constant,
                     norm, Operator, configuration)
-from fast.bench_utils import plot_3dfunc
 
 parser = argparse.ArgumentParser(description='Process arguments.')
 
@@ -25,6 +24,9 @@ parser.add_argument("-plot", "--plot", default=False, type=bool, help="Plot3D")
 parser.add_argument("-devito", "--devito", default=False, type=bool, help="Devito run")
 parser.add_argument("-xdsl", "--xdsl", default=False, type=bool, help="xDSL run")
 args = parser.parse_args()
+
+if args.plot:
+    from fast.bench_utils import plot_3dfunc
 
 mpiconf = configuration['mpi']
 

--- a/fast/wave2d_b.py
+++ b/fast/wave2d_b.py
@@ -7,9 +7,8 @@ from devito import (TimeFunction, Eq, Operator, solve, norm,
 from devito.tools import as_tuple
 
 import argparse
-from fast.bench_utils import plot_2dfunc
-
 np.set_printoptions(threshold=np.inf)
+
 
 parser = argparse.ArgumentParser(description='Process arguments.')
 
@@ -27,6 +26,9 @@ parser.add_argument("-plot", "--plot", default=False, type=bool, help="Plot2D")
 parser.add_argument("-devito", "--devito", default=False, type=bool, help="Devito run")
 parser.add_argument("-xdsl", "--xdsl", default=False, type=bool, help="xDSL run")
 args = parser.parse_args()
+
+if args.plot:
+    from fast.bench_utils import plot_2dfunc
 
 mpiconf = configuration['mpi']
 

--- a/fast/wave2d_b.py
+++ b/fast/wave2d_b.py
@@ -9,7 +9,6 @@ from devito.tools import as_tuple
 import argparse
 np.set_printoptions(threshold=np.inf)
 
-
 parser = argparse.ArgumentParser(description='Process arguments.')
 
 parser.add_argument("-d", "--shape", default=(16, 16), type=int, nargs="+",

--- a/fast/wave3d_b.py
+++ b/fast/wave3d_b.py
@@ -9,7 +9,6 @@ from devito.tools import as_tuple
 import argparse
 np.set_printoptions(threshold=np.inf)
 
-
 parser = argparse.ArgumentParser(description='Process arguments.')
 
 parser.add_argument("-d", "--shape", default=(16, 16, 16), type=int, nargs="+",

--- a/fast/wave3d_b.py
+++ b/fast/wave3d_b.py
@@ -7,9 +7,8 @@ from devito import (TimeFunction, Eq, Operator, solve, norm,
 from devito.tools import as_tuple
 
 import argparse
-from fast.bench_utils import plot_3dfunc
-
 np.set_printoptions(threshold=np.inf)
+
 
 parser = argparse.ArgumentParser(description='Process arguments.')
 
@@ -27,6 +26,9 @@ parser.add_argument("-plot", "--plot", default=False, type=bool, help="Plot2D")
 parser.add_argument("-devito", "--devito", default=False, type=bool, help="Devito run")
 parser.add_argument("-xdsl", "--xdsl", default=False, type=bool, help="xDSL run")
 args = parser.parse_args()
+
+if args.plot:
+    from fast.bench_utils import plot_3dfunc
 
 mpiconf = configuration['mpi']
 


### PR DESCRIPTION
It's the last benchmarking bottleneck at this point; triggering font cache rebuilds all over the place on ARCHER2/Cirrus, where we never use them!