### PR TITLE
Only load what is read.

### DIFF
--- a/devito/ir/ietxdsl/cluster_to_ssa.py
+++ b/devito/ir/ietxdsl/cluster_to_ssa.py
@@ -197,7 +197,7 @@ class ExtractDevitoStencilConversion:
             apply_arg.name_hint = apply_op.name_hint[:-5]+"_blk"
 
         self.apply_temps = {k:v for k,v in zip(temps.keys(), apply.region.block.args)}
-        print(self.apply_temps)
+        
         with ImplicitBuilder(apply.region.block):
             stencil.ReturnOp.get([self._visit_math_nodes(dim, eq.rhs, eq.lhs)])
 

--- a/tests/test_xdsl_base.py
+++ b/tests/test_xdsl_base.py
@@ -384,8 +384,6 @@ def test_xdsl_mul_eqs_IV():
         norm_u_xdsl = norm(u)
         norm_v_xdsl = norm(v)
 
-        import pdb;pdb.set_trace()
-
         assert np.isclose(norm_u_devito, 25.612497, rtol=0.0001)
         assert np.isclose(norm_v_devito, 25.612497, rtol=0.0001)
 

--- a/tests/test_xdsl_op_correctness.py
+++ b/tests/test_xdsl_op_correctness.py
@@ -64,4 +64,6 @@ def test_u_and_v_conversion():
     norm_v2 = norm(v)
 
     assert np.isclose(norm_u, norm_u2, atol=1e-5, rtol=0)
+    assert np.isclose(norm_u, 2.0664787, atol=1e-5, rtol=0)
     assert np.isclose(norm_v, norm_v2, atol=1e-5, rtol=0)
+    assert np.isclose(norm_v, 2.0664787, atol=1e-5, rtol=0)

--- a/tests/test_xdsl_op_correctness.py
+++ b/tests/test_xdsl_op_correctness.py
@@ -45,8 +45,8 @@ def test_u_plus1_conversion():
 def test_u_and_v_conversion():
     # Define a simple Devito Operator
     grid = Grid(shape=(3, 3))
-    u = TimeFunction(name='u', grid=grid, time_order=3)
-    v = TimeFunction(name='v', grid=grid, time_order=3)
+    u = TimeFunction(name='u', grid=grid, time_order=2)
+    v = TimeFunction(name='v', grid=grid, time_order=2)
     u.data[:] = 0.0001
     v.data[:] = 0.0001
     eq0 = Eq(u.forward, u.dx + v.dy)
@@ -64,6 +64,6 @@ def test_u_and_v_conversion():
     norm_v2 = norm(v)
 
     assert np.isclose(norm_u, norm_u2, atol=1e-5, rtol=0)
-    assert np.isclose(norm_u, 2.0664787, atol=1e-5, rtol=0)
+    assert np.isclose(norm_u, 2.0664592, atol=1e-5, rtol=0)
     assert np.isclose(norm_v, norm_v2, atol=1e-5, rtol=0)
-    assert np.isclose(norm_v, 2.0664787, atol=1e-5, rtol=0)
+    assert np.isclose(norm_v, 2.0664592, atol=1e-5, rtol=0)

--- a/tests/test_xdsl_op_correctness.py
+++ b/tests/test_xdsl_op_correctness.py
@@ -45,12 +45,12 @@ def test_u_plus1_conversion():
 def test_u_and_v_conversion():
     # Define a simple Devito Operator
     grid = Grid(shape=(3, 3))
-    u = TimeFunction(name='u', grid=grid, time_order=2)
-    v = TimeFunction(name='v', grid=grid, time_order=2)
+    u = TimeFunction(name='u', grid=grid, time_order=3)
+    v = TimeFunction(name='v', grid=grid, time_order=3)
     u.data[:] = 0.0001
     v.data[:] = 0.0001
-    eq0 = Eq(u.forward.forward, u.dt)
-    eq1 = Eq(v.forward.forward, u.dt)
+    eq0 = Eq(u.forward, u.dx + v.dy)
+    eq1 = Eq(v.forward, u.dy + v.dx)
     op = Operator([eq0, eq1])
     op.apply(time_M=5, dt=0.1)
     norm_u = norm(u)

--- a/tests/test_xdsl_op_correctness.py
+++ b/tests/test_xdsl_op_correctness.py
@@ -41,7 +41,7 @@ def test_u_plus1_conversion():
     assert np.isclose(norm1, norm2, atol=1e-5, rtol=0)
     assert np.isclose(norm1, 23.43075, atol=1e-5, rtol=0)
 
-@pytest.mark.xfail(reason="Needs a fix in offsets")
+
 def test_u_and_v_conversion():
     # Define a simple Devito Operator
     grid = Grid(shape=(3, 3))
@@ -49,8 +49,8 @@ def test_u_and_v_conversion():
     v = TimeFunction(name='v', grid=grid, time_order=2)
     u.data[:] = 0.0001
     v.data[:] = 0.0001
-    eq0 = Eq(u.forward, u.dt)
-    eq1 = Eq(v.forward, u.dt)
+    eq0 = Eq(u.forward.forward, u.dt)
+    eq1 = Eq(v.forward.forward, u.dt)
     op = Operator([eq0, eq1])
     op.apply(time_M=5, dt=0.1)
     norm_u = norm(u)
@@ -64,6 +64,4 @@ def test_u_and_v_conversion():
     norm_v2 = norm(v)
 
     assert np.isclose(norm_u, norm_u2, atol=1e-5, rtol=0)
-    assert np.isclose(norm_u, 26.565891, atol=1e-5, rtol=0)
     assert np.isclose(norm_v, norm_v2, atol=1e-5, rtol=0)
-    assert np.isclose(norm_v, 292.49646, atol=1e-5, rtol=0)


### PR DESCRIPTION
The codegen used to generates `stencil.load`s for any field that wasn't written to in a given equations, leading to superfluous `load`/`store` clashes when dealing with multiple equations. Now, only `load` the actual inputs to the equation at hand.