### PR TITLE
compiler: Reuse stored temps instead of trying to load from the field again.

### DIFF
--- a/devito/ir/ietxdsl/cluster_to_ssa.py
+++ b/devito/ir/ietxdsl/cluster_to_ssa.py
@@ -55,8 +55,11 @@ class ExtractDevitoStencilConversion:
 
     eqs: list[LoweredEq]
     block: Block
-    loaded_values: dict[tuple[int, ...], SSAValue]
+    temps: dict[tuple[DiscreteFunction, int], SSAValue]
     time_offs: int
+
+    def __init__(self):
+        self.temps = dict()
 
     def _convert_eq(self, eq: LoweredEq, **kwargs):
         """
@@ -182,22 +185,25 @@ class ExtractDevitoStencilConversion:
         read_functions = set()
         for f in retrieve_function_carriers(eq.rhs):
             read_functions.add((f.function, (f.indices[dim]-dim) % f.function.time_size))
-      
-        temps = {
-            (f, t): stencil.LoadOp.get(a).res
-            for (f, t), a in self.block_args.items()
-            if (f, t) in read_functions
-        }
-        for (f,t), a in temps.items():
-            a.name_hint = f"{f.name}_t{t}_temp"        
+
+        for f, t in read_functions:
+            if (f, t) not in self.temps:
+                self.temps[(f, t)] = stencil.LoadOp.get(self.block_args[(f, t)]).res
+                self.temps[(f, t)].name_hint = f"{f.name}_t{t}_temp"
 
         write_function = self.out_time_buffer[0]
         shape = write_function.grid.shape_local
+        apply_args = [self.temps[f] for f in read_functions]
         apply = stencil.ApplyOp.get(
-            temps.values(),
-            Block(arg_types=[a.type for a in temps.values()]),
-            result_types=[stencil.TempType(len(shape), element_type=dtypes_to_xdsltypes[write_function.dtype])]
+            apply_args,
+            Block(arg_types=[a.type for a in apply_args]),
+            result_types=[
+                stencil.TempType(
+                    len(shape), element_type=dtypes_to_xdsltypes[write_function.dtype]
+                )
+            ],
         )
+        apply.res[0].name_hint = f"{write_function.name}_t{self.out_time_buffer[1]}_temp"
 
         # Give names to stencil.apply's block arguments
         for apply_arg, apply_op in zip(apply.region.block.args, apply.operands):
@@ -206,8 +212,8 @@ class ExtractDevitoStencilConversion:
             assert "temp" in apply_op.name_hint
             apply_arg.name_hint = apply_op.name_hint.replace("temp", "blk")
 
-        self.apply_temps = {k:v for k,v in zip(temps.keys(), apply.region.block.args)}
-        
+        self.apply_temps = {k:v for k,v in zip(read_functions, apply.region.block.args)}
+
         with ImplicitBuilder(apply.region.block):
             stencil.ReturnOp.get([self._visit_math_nodes(dim, eq.rhs, eq.lhs)])
 
@@ -218,6 +224,7 @@ class ExtractDevitoStencilConversion:
             self.block_args[self.out_time_buffer],
             stencil.StencilBoundsAttr(zip(lb ,ub))
         )
+        self.temps[self.out_time_buffer] = apply.res[0]
 
     def convert(self, eqs: Iterable[Eq], **kwargs) -> builtin.ModuleOp:
         """
@@ -473,7 +480,6 @@ class MakeFunctionTimed(TimerRewritePattern):
             func.FuncOp.external('timer_start', [], [builtin.f64]),
             func.FuncOp.external('timer_end', [builtin.f64], [builtin.f64])
         ])
-
 
 
 def get_containing_func(op: Operation) -> func.FuncOp | None:

--- a/tests/test_xdsl_base.py
+++ b/tests/test_xdsl_base.py
@@ -731,6 +731,7 @@ def test_xdsl_mul_eqs_VI():
     assert np.isclose(u.data, devito_res_u.data).all()
     assert np.isclose(v.data, devito_res_v.data).all()
 
+
 class TestOperatorUnsupported(object):
 
     @pytest.mark.xfail(reason="Symbols are not supported in xDSL yet")

--- a/tests/test_xdsl_base.py
+++ b/tests/test_xdsl_base.py
@@ -700,7 +700,7 @@ class TestAntiDepNotSupported(object):
         op.apply(time_M=1)
 
 
-def test_xdsl_mul_eqs_V():
+def test_xdsl_mul_eqs_VI():
     # Define a Devito Operator with multiple eqs
     grid = Grid(shape=(4, 4))
 

--- a/tests/test_xdsl_base.py
+++ b/tests/test_xdsl_base.py
@@ -709,9 +709,9 @@ def test_xdsl_mul_eqs_VI():
 
     u.data[:, :, :] = np.random.rand(*u.shape)
     v.data[:, :, :] = np.random.rand(*v.shape)
-    
-    u_init = u.data[:,:,:]
-    v_init = v.data[:,:,:]
+
+    u_init = u.data[:, :, :]
+    v_init = v.data[:, :, :]
 
     eq0 = Eq(u.forward, u + 2)
     eq1 = Eq(v, u.forward * 2)
@@ -720,9 +720,9 @@ def test_xdsl_mul_eqs_VI():
 
     op.apply(time_M=4, dt=0.1)
 
-    devito_res_u = u.data_with_halo[:,:,:]
-    devito_res_v = v.data_with_halo[:,:,:]
-    
+    devito_res_u = u.data_with_halo[:, :, :]
+    devito_res_v = v.data_with_halo[:, :, :]
+
     u.data[:, :, :] = u_init
     v.data[:, :, :] = v_init
 
@@ -732,6 +732,7 @@ def test_xdsl_mul_eqs_VI():
 
     assert np.isclose(u.data_with_halo, devito_res_u).all()
     assert np.isclose(v.data_with_halo, devito_res_v).all()
+
 
 @pytest.mark.xfail(reason=" .forward.dx cannot be handled")
 def test_xdsl_mul_eqs_VII():
@@ -743,26 +744,25 @@ def test_xdsl_mul_eqs_VII():
 
     u.data[:, :, :] = 0.1
     v.data[:, :, :] = 0.1
-    
+
     eq0 = Eq(u.forward, u + 2)
     eq1 = Eq(v, u.forward.dx * 2)
 
     op = Operator([eq0, eq1], opt="advanced")
     op.apply(time_M=4, dt=0.1)
 
-    devito_res_u = u.data_with_halo[:,:,:]
-    devito_res_v = v.data_with_halo[:,:,:]
-    
+    devito_res_u = u.data_with_halo[:, :, :]
+    devito_res_v = v.data_with_halo[:, :, :]
+
     u.data[:, :, :] = 0.1
     v.data[:, :, :] = 0.1
 
-    import pdb;pdb.set_trace()
     op = Operator([eq0, eq1], opt="xdsl")
     op.apply(time_M=4, dt=0.1)
 
-    import pdb;pdb.set_trace()
     assert np.isclose(norm(u), np.linalg.norm(devito_res_u))
     assert np.isclose(norm(v), np.linalg.norm(devito_res_v))
+
 
 def test_xdsl_mul_eqs_VIII():
     # Define a Devito Operator with multiple eqs
@@ -773,23 +773,21 @@ def test_xdsl_mul_eqs_VIII():
 
     u.data[:, :, :] = 0.1
     v.data[:, :, :] = 0.1
-    
+
     eq0 = Eq(v, u.forward.dx * 2)
 
-    op = Operator([eq1], opt="advanced")
+    op = Operator([eq0], opt="advanced")
     op.apply(time_M=4, dt=0.1)
 
-    devito_res_u = u.data_with_halo[:,:,:]
-    devito_res_v = v.data_with_halo[:,:,:]
-    
+    devito_res_u = u.data_with_halo[:, :, :]
+    devito_res_v = v.data_with_halo[:, :, :]
+
     u.data[:, :, :] = 0.1
     v.data[:, :, :] = 0.1
 
-    import pdb;pdb.set_trace()
     op = Operator([eq0], opt="xdsl")
     op.apply(time_M=4, dt=0.1)
 
-    import pdb;pdb.set_trace()
     assert np.isclose(norm(u), np.linalg.norm(devito_res_u))
     assert np.isclose(norm(v), np.linalg.norm(devito_res_v))
 

--- a/tests/test_xdsl_base.py
+++ b/tests/test_xdsl_base.py
@@ -704,8 +704,8 @@ def test_xdsl_mul_eqs_VI():
     # Define a Devito Operator with multiple eqs
     grid = Grid(shape=(4, 4))
 
-    u = TimeFunction(name="u", grid=grid, time_order=3, space_order=2)
-    v = TimeFunction(name="v", grid=grid, time_order=3, space_order=2)
+    u = TimeFunction(name="u", grid=grid, time_order=2)
+    v = TimeFunction(name="v", grid=grid, time_order=2)
     u.data[:, :, :] = np.random.rand(*u.shape)
     v.data[:, :, :] = np.random.rand(*v.shape)
     u_init = u.data.copy()
@@ -730,7 +730,6 @@ def test_xdsl_mul_eqs_VI():
 
     assert np.isclose(u.data, devito_res_u.data).all()
     assert np.isclose(v.data, devito_res_v.data).all()
-
 
 class TestOperatorUnsupported(object):
 

--- a/tests/test_xdsl_op_correctness.py
+++ b/tests/test_xdsl_op_correctness.py
@@ -87,22 +87,21 @@ def test_u_and_v_conversion():
 
     scffor_ops = list(ops[6].regions[0].blocks[0].ops)
     
-    assert len(scffor_ops) == 9
-
-    # First
+    assert len(scffor_ops) == 7
+    
     assert isinstance(scffor_ops[0], LoadOp)
     assert isinstance(scffor_ops[1], LoadOp)
+
+    # First
     assert isinstance(scffor_ops[2], ApplyOp)
     assert isinstance(scffor_ops[3], StoreOp)
 
     # Second
-    assert isinstance(scffor_ops[4], LoadOp)
-    assert isinstance(scffor_ops[5], LoadOp)
-    assert isinstance(scffor_ops[6], ApplyOp)
-    assert isinstance(scffor_ops[7], StoreOp)
+    assert isinstance(scffor_ops[4], ApplyOp)
+    assert isinstance(scffor_ops[5], StoreOp)
 
     # Yield
-    assert isinstance(scffor_ops[8], Yield)
+    assert isinstance(scffor_ops[6], Yield)
 
     assert type(ops[7] == Call)
     assert type(ops[8] == StoreOp)


### PR DESCRIPTION
High-level desc:
[Eq(u, 5), Eq(v, u)] would fail, because first equation would `stencil.store(u_res, u)` and the second would `stencil.load(u)` for its input, failing verifications. (cannot load and store from the same field)
This is a simple fix simply reusing `u_res` in the second equation's codegen instead of `stencil.load`ing the buffer again.